### PR TITLE
ImageManager: delete fix :angel:

### DIFF
--- a/src/ondrs/UploadManager/Managers/ImageManager.php
+++ b/src/ondrs/UploadManager/Managers/ImageManager.php
@@ -293,13 +293,12 @@ class ImageManager extends Object implements IManager
             $filter[] = 'orig';
         }
 
-        $filter = array_map(function ($i) use ($filename) {
-            return $i . '_' . $filename;
+        $filter = array_map(function ($i) use ($filename, $namespace) {
+            return $namespace . '/' . $i . '_' . $filename;
         }, $filter);
 
-        $filter[] = $filename;
+        $filter[] = $namespace . '/' . $filename;
 
-        $files = array_keys($this->storage->find($namespace, $filter));
-        $this->storage->bulkDelete($files);
+        $this->storage->bulkDelete($filter);
     }
 }


### PR DESCRIPTION
Mám pocit, že nefunguje delete. ImageManager::delete přes `find` najde plnou cestu k souboru ale FileStorage::delete očekává relativní a tu absolutní vytváří. Takže se to tam duplikuje imho.

Bug bych řekl, že tam je, jestli se ti bude líbit ta oprava nevim.

A testy mi nejdou rozjet :(
